### PR TITLE
feat: add `isFirst` and `isLast` slot properties to `Step`

### DIFF
--- a/src/components/LinearStepper.story.vue
+++ b/src/components/LinearStepper.story.vue
@@ -4,7 +4,7 @@
 </script>
 
 <template>
-    <Story title="Linear Stepper" :layout="{type: 'single', iframe: false}">
+    <Story title="Linear Stepper" :layout="{ type: 'single', iframe: false }">
         <LinearStepper v-slot="{ current, previous, hasPrevious, next, hasNext }">
             <div>current step: {{ current }}</div>
             <div>has previous steps: {{ hasPrevious }}</div>
@@ -13,11 +13,20 @@
                 <button type="button" @click="previous" :disabled="!hasPrevious">Previous</button>
                 <button type="button" @click="next" :disabled="!hasNext">Next</button>
             </div>
-            <Step :position="0">
+            <Step :position="0" v-slot="{ isFirst, isLast }">
                 Step 0
+                <div>is first: {{ isFirst }}</div>
+                <div>is last: {{ isLast }}</div>
             </Step>
-            <Step :position="1">
+            <Step :position="1" v-slot="{ isFirst, isLast }">
                 Step 1
+                <div>is first: {{ isFirst }}</div>
+                <div>is last: {{ isLast }}</div>
+            </Step>
+            <Step :position="2" v-slot="{ isFirst, isLast }">
+                Step 2
+                <div>is first: {{ isFirst }}</div>
+                <div>is last: {{ isLast }}</div>
             </Step>
         </LinearStepper>
     </Story>

--- a/src/components/LinearStepper.vue
+++ b/src/components/LinearStepper.vue
@@ -67,8 +67,9 @@ import { registerInjectionKey } from '../inject';
      * Provide the `register` function to all child Step components.
      */
     provide(registerInjectionKey, register);
-    
+
     provide('current', current);
+    provide('steps', steps);
 </script>
 
 <template>

--- a/src/components/Step.vue
+++ b/src/components/Step.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-    import { inject, onMounted, Ref, ref } from 'vue';
+    import { computed, inject, onMounted, Ref, ref } from 'vue';
     import { registerInjectionKey } from '../inject';
 
     const props = defineProps<{
@@ -15,6 +15,33 @@
      * Current step of the parent stepper
      */
     const current = inject<Ref<number>>('current');
+
+    /**
+     * Reference to all the steps currently in the stepper
+     */
+    const steps = inject<Ref<Ref[]>>('steps');
+
+    /**
+     * Tells whether the step is the first step in the stepper
+     */
+    const isFirst = computed<boolean | undefined>(() => {
+        if (current?.value !== undefined && steps?.value !== undefined) {
+            return props.position === 0;
+        }
+
+        return undefined;
+    });
+
+    /**
+     * Tells whether the step is the last step in the stepper
+     */
+    const isLast = computed<boolean | undefined>(() => {
+        if (current?.value !== undefined && steps?.value !== undefined) {
+            return props.position === steps.value.length - 1;
+        }
+
+        return undefined;
+    });
 
     /**
      * A reference to the step component
@@ -35,5 +62,5 @@
 </script>
 
 <template>
-    <slot v-if="current === props.position" ref="step" />
+    <slot v-if="current === props.position" ref="step" :position="props.position" :is-first="isFirst" :is-last="isLast" />
 </template>


### PR DESCRIPTION
This PR adds two new slots properties to the `Step` component.

- The `isFirst` slot property can be used to determine whether the step is the first step in the stepper.

- the `isLast` slot property can be used to determine whether the step is the last step in the stepper.

### Example

```html
<LinearStepper>
  <Step :position="0" v-slot="{ isFirst, isLast }">
      <div>is first: {{ isFirst }}</div> <!-- true -->
      <div>is last: {{ isLast }}</div> <!-- false -->
  </Step>
  <Step :position="1" v-slot="{ isFirst, isLast }">
      <div>is first: {{ isFirst }}</div> <!-- false -->
      <div>is last: {{ isLast }}</div> <!-- false -->
  </Step>
  <Step :position="2" v-slot="{ isFirst, isLast }">
      <div>is first: {{ isFirst }}</div> <!-- false -->
      <div>is last: {{ isLast }}</div> <!-- true -->
  </Step>
</LinearStepper>
```
